### PR TITLE
Enable gateway HTTP/2 routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,11 @@ cargo run -p xtask -- cert --out-dir docker/compose/certs
 - `cargo run -p xtask -- lint`：执行 Rust 侧 lint 任务。
 - `cargo run -p xtask -- cert --out-dir docker/compose/certs`：生成本地 CA 与站点证书。
 
+开发过程中的容器管理约定：
+
+- 开发过程中如需启动、重建或同步 Docker 服务，优先使用 `cargo run -p xtask -- compose`。
+- 不要默认直接使用 `docker compose up` 替代 `xtask compose`，除非任务明确要求；`xtask compose` 会按仓库约定处理 network、volume、container 的就绪顺序，更符合当前项目工作流。
+
 单服务调试：
 
 ```bash
@@ -121,6 +126,7 @@ cargo run -p collections
 - 当用户要求进行 GitHub 相关操作（如 issue、PR、release、workflow、评论、查看状态）时，统一优先使用 `gh` 命令行。
 - 若执行 `gh` 时遇到权限不足、未登录或认证失败，优先判断为沙盒限制导致；不要自行绕过，应向用户申请权限后再继续。
 - 当用户要求编写 issue 内容时，必须先查看 `.github` 目录下的相关文档与模板，优先参考 `.github/ISSUE_TEMPLATE/*.yml`，并按仓库现有模板结构与字段组织内容。
+- 执行 `git commit`、`git push` 等可能触发 git hooks 的命令时，必须等待 hook 完整执行结束，不要因为等待时间较长就改用 `--no-verify` 或跳过；若怀疑卡住，应先确认具体卡在哪个检查步骤，再与用户同步。
 
 ## 故障排查提示
 

--- a/server/packages/gateway/src/main.rs
+++ b/server/packages/gateway/src/main.rs
@@ -10,6 +10,8 @@ mod route;
 #[cfg(not(windows))]
 use config::GatewayConfig;
 #[cfg(not(windows))]
+use pingora::listeners::tls::TlsSettings;
+#[cfg(not(windows))]
 use pingora::prelude::*;
 #[cfg(not(windows))]
 use proxy::GatewayProxy;
@@ -36,7 +38,9 @@ fn main() -> Result<()> {
 
     let mut service = http_proxy_service(&server.configuration, GatewayProxy::new(routes, &config));
     service.add_tcp(&config.listen_http);
-    service.add_tls(&config.listen_https, &config.tls_cert, &config.tls_key)?;
+    let mut tls_settings = TlsSettings::intermediate(&config.tls_cert, &config.tls_key)?;
+    tls_settings.enable_h2();
+    service.add_tls_with_settings(&config.listen_https, None, tls_settings);
     server.add_service(service);
 
     event!(
@@ -45,6 +49,7 @@ fn main() -> Result<()> {
         listen_https = config.listen_https,
         tls_cert = config.tls_cert,
         tls_key = config.tls_key,
+        http2_enabled = true,
         "gateway started"
     );
 

--- a/server/packages/gateway/src/proxy.rs
+++ b/server/packages/gateway/src/proxy.rs
@@ -62,6 +62,25 @@ const HEADER_TRACE_PARENT: &str = "traceparent";
 const HEADER_X_REQUEST_ID: &str = "x-request-id";
 const HEADER_TRACE_ID: &str = "trace-id";
 
+fn normalize_host(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    let value = value
+        .strip_prefix('[')
+        .and_then(|value| value.split_once(']').map(|(host, _rest)| host))
+        .unwrap_or_else(|| value.split(':').next().unwrap_or_default());
+    let value = value.trim();
+
+    if value.is_empty() {
+        return None;
+    }
+
+    Some(value.to_ascii_lowercase())
+}
+
 fn header_to_string(headers: &http::HeaderMap, name: &'static str) -> Option<String> {
     headers
         .get(name)
@@ -69,6 +88,16 @@ fn header_to_string(headers: &http::HeaderMap, name: &'static str) -> Option<Str
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
+}
+
+fn request_host(req: &RequestHeader) -> String {
+    req.uri
+        .host()
+        .map(ToString::to_string)
+        .or_else(|| header_to_string(&req.headers, "host"))
+        .or_else(|| req.uri.authority().map(|authority| authority.as_str().to_string()))
+        .and_then(|value| normalize_host(&value))
+        .unwrap_or_default()
 }
 
 fn is_hex(value: &str) -> bool {
@@ -159,15 +188,7 @@ impl ProxyHttp for GatewayProxy {
 
     async fn request_filter(&self, session: &mut Session, ctx: &mut Self::CTX) -> Result<bool> {
         let req = session.req_header();
-        let host = req
-            .headers
-            .get("host")
-            .and_then(|value| value.to_str().ok())
-            .unwrap_or_default()
-            .split(':')
-            .next()
-            .unwrap_or_default()
-            .to_ascii_lowercase();
+        let host = request_host(req);
 
         let path = req.uri.path().to_string();
         let path_and_query = req
@@ -255,16 +276,7 @@ impl ProxyHttp for GatewayProxy {
     where
         Self::CTX: Send + Sync,
     {
-        let host = session
-            .req_header()
-            .headers
-            .get("host")
-            .and_then(|value| value.to_str().ok())
-            .unwrap_or_default()
-            .split(':')
-            .next()
-            .unwrap_or_default()
-            .to_ascii_lowercase();
+        let host = request_host(session.req_header());
 
         if !host.is_empty() {
             upstream_request.remove_header("Host");
@@ -324,15 +336,7 @@ impl ProxyHttp for GatewayProxy {
     {
         let req = session.req_header();
         let method = req.method.as_str();
-        let host = req
-            .headers
-            .get("host")
-            .and_then(|value| value.to_str().ok())
-            .unwrap_or_default()
-            .split(':')
-            .next()
-            .unwrap_or_default()
-            .to_ascii_lowercase();
+        let host = request_host(req);
         let path = req
             .uri
             .path_and_query()
@@ -377,5 +381,33 @@ impl ProxyHttp for GatewayProxy {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_host, request_host};
+    use pingora::http::RequestHeader;
+
+    #[test]
+    fn request_host_prefers_host_header() {
+        let mut req = RequestHeader::build("GET", b"/", None).expect("request");
+        req.insert_header("host", "sushao.top:443").expect("host");
+        assert_eq!(request_host(&req), "sushao.top");
+    }
+
+    #[test]
+    fn request_host_falls_back_to_uri_authority() {
+        let mut req = RequestHeader::build("GET", b"/graphql", None).expect("request");
+        req.set_uri("https://collections.sushao.top/graphql".parse().expect("uri"));
+        assert_eq!(request_host(&req), "collections.sushao.top");
+    }
+
+    #[test]
+    fn normalize_host_supports_ipv6_authority() {
+        assert_eq!(
+            normalize_host("[2001:db8::1]:443"),
+            Some("2001:db8::1".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary
- enable HTTP/2 on the gateway TLS listener while preserving HTTP/1.1 fallback via ALPN
- fix gateway host routing for HTTP/2 requests by reading the URI host/authority instead of relying only on the Host header
- document that development container orchestration should use `cargo run -p xtask -- compose`

## Testing
- cargo test -p gateway
- cargo clippy --all
- cargo run -p xtask -- compose
- curl --noproxy '*' -kI --http2 --resolve sushao.top:443:127.0.0.1 https://sushao.top/

Closes #81.
